### PR TITLE
delete foo.txt file created by Encoding example when running tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! CycloneDx-Rust is a Crate library for encoding and decoding [CycloneDx](https://cyclonedx.org/) files in both XML and JSON format
 //! to the 1.2 spec
 //!
-//! To encode the CycloneDx you cab=n either build up the structure using the provided <X>::new() methods, passing in the parameters where necessary
+//! To encode the CycloneDx you can either build up the structure using the provided <X>::new() methods, passing in the parameters where necessary
 //! or make use of the builder pattern.
 //! The builder patterns are created at build time so intelli-sense may not be available. Howver, each struct, for example:
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,14 @@
 //! use cyclonedx_rust::{CycloneDX, CycloneDXFormatType};
 //! use std::io::BufWriter;
 //! use std::fs::File;
+//! use std::fs;
 //!
-//! let mut buffer = BufWriter::new(File::create("foo.txt").unwrap());
+//! const FOO_TXT: &str = "foo.txt";
+//! let mut buffer = BufWriter::new(File::create(FOO_TXT).unwrap());
 //! let cyclone_dx = CycloneDX::new(None, None, None, None);
 //! CycloneDX::encode(&mut buffer, cyclone_dx, CycloneDXFormatType::XML);
+//! // cleanup test file
+//! fs::remove_file(FOO_TXT);
 //! ```
 //!
 //! # Decoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! To encode the CycloneDx you can either build up the structure using the provided <X>::new() methods, passing in the parameters where necessary
 //! or make use of the builder pattern.
-//! The builder patterns are created at build time so intelli-sense may not be available. Howver, each struct, for example:
+//! The builder patterns are created at build time so intelli-sense may not be available. However, each struct, for example:
 //! ```
 //! use cyclonedx_rust::CycloneDX;
 //!


### PR DESCRIPTION
Minor thing, not sure how best to fix, but I noticed after running the tests, a `foo.txt` file is created in the project root dir.
This PR adds a step to the example that created the file to delete that file it created. (BTW, docs that compile are wicked cool!)