### PR TITLE
Result warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! CycloneDx-Rust is a Crate library for encoding and decoding [CycloneDx](https://cyclonedx.org/) files in both XML and JSON format
 //! to the 1.2 spec
 //!
-//! To encode the CycloneDx you cab=n either build up the structure using the provided <X>::new() methods, passing in the parameters where necessary
+//! To encode the CycloneDx you can either build up the structure using the provided <X>::new() methods, passing in the parameters where necessary
 //! or make use of the builder pattern.
 //! The builder patterns are created at build time so intelli-sense may not be available. Howver, each struct, for example:
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,9 @@ mod tests {
     pub fn can_recode_xml() {
         let mut buffer = Vec::new();
         let cyclone_dx = CycloneDX::new(None, None, None, None);
-        CycloneDX::encode(&mut buffer, cyclone_dx, CycloneDXFormatType::XML);
+        let encode_result = CycloneDX::encode(&mut buffer, cyclone_dx, CycloneDXFormatType::XML);
+        assert!(encode_result.is_ok());
+
         let response = CycloneDX::decode(&buffer[..], CycloneDXFormatType::XML).unwrap();
 
         assert_eq!(response.version, "1");
@@ -295,7 +297,8 @@ mod tests {
     pub fn can_encode_basic_xml() {
         let mut writer = Vec::new();
         let cyclone_dx = CycloneDX::new(None, None, None, None);
-        CycloneDX::encode(&mut writer, cyclone_dx, CycloneDXFormatType::XML);
+        let encode_result = CycloneDX::encode(&mut writer, cyclone_dx, CycloneDXFormatType::XML);
+        assert!(encode_result.is_ok());
 
         let result = String::from_utf8(writer).unwrap();
         assert!(!result.contains("CycloneDX"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,14 @@
 //! use cyclonedx_rust::{CycloneDX, CycloneDXFormatType};
 //! use std::io::BufWriter;
 //! use std::fs::File;
+//! use std::fs;
 //!
-//! let mut buffer = BufWriter::new(File::create("foo.txt").unwrap());
+//! const FOO_TXT: &str = "foo.txt";
+//! let mut buffer = BufWriter::new(File::create(FOO_TXT).unwrap());
 //! let cyclone_dx = CycloneDX::new(None, None, None, None);
 //! CycloneDX::encode(&mut buffer, cyclone_dx, CycloneDXFormatType::XML);
+//! // cleanup test file
+//! fs::remove_file(FOO_TXT);
 //! ```
 //!
 //! # Decoding

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! To encode the CycloneDx you can either build up the structure using the provided <X>::new() methods, passing in the parameters where necessary
 //! or make use of the builder pattern.
-//! The builder patterns are created at build time so intelli-sense may not be available. Howver, each struct, for example:
+//! The builder patterns are created at build time so intelli-sense may not be available. However, each struct, for example:
 //! ```
 //! use cyclonedx_rust::CycloneDX;
 //!


### PR DESCRIPTION
Another silly one. (Rust noob alert!) This PR fixes a compiler warning due to not use the result (that could be an error) from the call to `CycloneDX::encode()`. (Warnings showed up after I commented out the `unimplemented!();` bits, just to see how it blows up).

Doh! I meant for this PR to build on PR #2, but didn't think about having no commit in your repo to link to. Sorry for the mess.