### PR TITLE
Fix doc command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Encoding:
 CycloneDX::encode<(writer: W, dx: CycloneDX, format: CycloneDXFormatType,) -> Result<(), CycloneDXEncodeError>
 ```
 
-Run `cargo docs --open` for more detailed documentation
+Run `cargo doc --open` for more detailed documentation


### PR DESCRIPTION
The current command results in:
```shell
$ cargo docs --open
error: no such command: `docs`

        Did you mean `doc`?

        View all installed commands with `cargo --list`
```

While the corrected command results in the following desired behavior:
```shell
$ cargo doc --open
```